### PR TITLE
feat: add json metadata to pipeline

### DIFF
--- a/pipeline/bin/pipeline.dart
+++ b/pipeline/bin/pipeline.dart
@@ -1,5 +1,7 @@
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:collection/collection.dart';
 import 'package:csv/csv.dart';
 import 'package:pipeline/fasta.dart';
 import 'package:pipeline/fasta_generator.dart';
@@ -16,6 +18,7 @@ void main(List<String> arguments) async {
   final organismFolderName = arguments[0];
   final organism = OrganismFactory.getOrganism(organismFolderName);
   final useTss = arguments.contains('--with-tss');
+  final noComments = arguments.contains('--no-comments');
 
   // Find files
   print('Searching input data for `${organism.name}`. TSS: $useTss');
@@ -112,6 +115,7 @@ void main(List<String> arguments) async {
 
   // Save the output fasta file
   final fastaOutputFile = File('$outputPath/$organismFolderName${useTss ? '-with-tss' : ''}.fasta');
+  final metadataOutputFile = File('$outputPath/$organismFolderName${useTss ? '-with-tss' : ''}.metadata.json');
   final fastaSink = fastaOutputFile.openWrite(mode: FileMode.writeOnly);
   final generator = FastaGenerator(
     gff,
@@ -121,16 +125,60 @@ void main(List<String> arguments) async {
     useSelfInsteadOfStartCodon: organism.useSelfInsteadOfStartCodon,
     useAtg: organism.useAtg,
   );
+  
+  final metadataResult = <String, dynamic>{};
+
   await for (final gene in generator.toFasta(organism.deltaBases)) {
-    fastaSink.writeln(gene.join("\n"));
+    if (noComments) {
+      fastaSink.writeln(gene.where((line) => !line.startsWith(';')).join('\n'));
+      metadataResult.addAll(toJson(gene));
+    } else {
+      fastaSink.writeln(gene.join("\n"));
+    }
   }
+
+  if (noComments) {
+    final encoder = JsonEncoder.withIndent('  ');
+    final jsonString = encoder.convert(metadataResult);
+
+    await metadataOutputFile.writeAsString(jsonString);
+    print('Wrote json to `${metadataOutputFile.path}`');
+  }
+
   await fastaSink.flush();
   await fastaSink.close();
+  
   print('Wrote fasta to `${fastaOutputFile.path}`');
   await fasta.cleanup();
   print('Cleaned up temporary files');
 
   exit(0);
+}
+
+Map<String, dynamic> toJson(List<String> metadataLines) {
+  final source = getMetadataLine(metadataLines, ';SOURCE');
+  final description = getMetadataLine(metadataLines, ';DESCRIPTION');
+  final markers = getMetadataLine(metadataLines, ';MARKERS');
+  final transcriptionRates =
+      getMetadataLine(metadataLines, ';TRANSCRIPTION_RATES');
+  final transcriptId = RegExp(r'^>([^\s]*)').firstMatch(metadataLines[0])!.group(1);
+
+  return {
+    transcriptId!: {
+      'source': source,
+      'description': description,
+      'markers': markers != null ? jsonDecode(markers) : null,
+      'transcriptionRates':
+          transcriptionRates != null ? jsonDecode(transcriptionRates) : null,
+    }
+  };
+}
+
+String? getMetadataLine(List<String> metadataLines, String lineKey) {
+  return metadataLines
+      .firstWhereOrNull((line) => line.startsWith(lineKey))
+      ?.split(' ')
+      .firstOrNull;
 }
 
 /// Holds the paths to the source files

--- a/pipeline/bin/pipeline.dart
+++ b/pipeline/bin/pipeline.dart
@@ -178,7 +178,7 @@ String? getMetadataLine(List<String> metadataLines, String lineKey) {
   return metadataLines
       .firstWhereOrNull((line) => line.startsWith(lineKey))
       ?.split(' ')
-      .firstOrNull;
+      .lastOrNull;
 }
 
 /// Holds the paths to the source files


### PR DESCRIPTION
Added the ability to generate fasta files without comments. The metadata are in a separate `<input_name>.metadata.json` file.

The json structure:
```json
{
  "Azfi_s0001.g000023": {
    "source": "Azfi_s0001.g000023 lcl|Azfi_s0001 mRNA 414292 425405 forward ID=Azfi_s0001.g000023.mRNA1;Parent=Azfi_s0001.g000023;Alias=Azfi_s0001.g000023;Name=Azfi_s0001.g000023.mRNA1;coge_fid=1343093952;mRNA=Azfi_s0001.g000023.mRNA1",
    "description": null,
    "transcriptionRates": {
      "Leaves": 253.2621,
      "Spores": 59.6692
    },
    "markers": {
      "atg": 1143,
      "tss": 1001
    }
  },
  "Azfi_s0001.g000024": {
    "source": "SOURCE Azfi_s0001.g000024 lcl|Azfi_s0001 mRNA 426029 431460 reverse ID=Azfi_s0001.g000024.mRNA1;Parent=Azfi_s0001.g000024;Alias=Azfi_s0001.g000024;Name=Azfi_s0001.g000024.mRNA1;coge_fid=1343093958;mRNA=Azfi_s0001.g000024.mRNA1",
    "description": null,
    "transcriptionRates": {
      "Leaves": 51.44175,
      "Spores": 27.975967
    },
    "markers": {
      "atg": 1135,
      "tss": 1001
    }
  },
  ...
}
```